### PR TITLE
Add a CI job to verify changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/erlide_tools
+          ~/.kerl
+        key: ${{ runner.os }}-otp-${{ hashFiles('build_utils.sh') }}
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'zulu'
+        cache: 'maven'
+    - name: Build
+      run: ./build
+    - name: Test
+      run: ./build test
+    - name: Dialyzer
+      continue-on-error: true    # Until problems are fixed
+      run: ./build dialyzer
+    - name: Xref
+      continue-on-error: true    # Until problems are fixed
+      run: ./build xref
+    - name: Build zip archive for Eclipse
+      continue-on-error: true    # Until problems are fixed
+      run: cd eclipse && ./build


### PR DESCRIPTION
The run time is shortened by caching the Java/Maven packages and
the directories that contains the Erlang versions built by `kerl`.

- Dialyzer and Xref indicates issues that needs to be handled. 
- There is also an issue with the Eclipse packaging on Github.

The job will fail until using >=`OTP 23` since `kerl` is not supporting older versions.

Example of run that includes the lifted OTP:
https://github.com/Nordix/erlide_kernel/actions/runs/3995780691