### PR TITLE
Lift Tycho to 1.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,4 @@ jobs:
       continue-on-error: true    # Until problems are fixed
       run: ./build xref
     - name: Build zip archive for Eclipse
-      continue-on-error: true    # Until problems are fixed
       run: cd eclipse && ./build

--- a/eclipse/pom.xml
+++ b/eclipse/pom.xml
@@ -10,7 +10,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho.version>0.24.0</tycho.version>
+		<tycho.version>1.7.0</tycho.version>
 		<tycho-extras-version>${tycho.version}</tycho-extras-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
Tycho is a set of Maven plugins for building Eclipse plugins.

Using the same version of Tycho as is used in `erlide_eclipse` fixes the CI issue regarding getting the commit timestamp.